### PR TITLE
Add signing, sourcesJar and javadocJar

### DIFF
--- a/plugin-maven-publish/build.gradle
+++ b/plugin-maven-publish/build.gradle
@@ -1,10 +1,26 @@
 plugins {
     id("java-gradle-plugin")
+    id("signing")
     id("maven-publish")
 }
 
 group = "org.example"
-version = "0.1"
+version = "0.1-SNAPSHOT"
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar) {
+    from javadoc
+    classifier = 'javadoc'
+}
+
+signing {
+    useGpgCmd()
+    sign(publishing.publications)
+}
 
 gradlePlugin {
     plugins {
@@ -18,6 +34,13 @@ gradlePlugin {
 }
 
 publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+                artifact sourcesJar
+                artifact javadocJar
+        }
+    }
     // afterEvaluate is necessary because java-gradle-plugin
     // creates its publications in an afterEvaluate callback
     afterEvaluate {
@@ -45,7 +68,7 @@ publishing {
     repositories {
         maven {
             name = "local"
-            url = file("repo")
+            url = file("build/repo")
         }
     }
 }

--- a/plugin-maven-publish/build.gradle
+++ b/plugin-maven-publish/build.gradle
@@ -34,13 +34,6 @@ gradlePlugin {
 }
 
 publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-                artifact sourcesJar
-                artifact javadocJar
-        }
-    }
     // afterEvaluate is necessary because java-gradle-plugin
     // creates its publications in an afterEvaluate callback
     afterEvaluate {
@@ -53,6 +46,8 @@ publishing {
             }
             pluginMaven {
                 // customize main publications here
+                artifact sourcesJar
+                artifact javadocJar
                 pom {
                     name = "main artifact"
                 }


### PR DESCRIPTION
_This PR is opened for discussion. It is not really intended to be merged_

In my attempt to publish a gradle plugin to maven central directly with the gradle standard plugins (no third party plugin for publish), thanks to your help @marcphilipp I was able to understand how to customise `pom.xml` of the marker artifact. With the project `` in this repository.

You have also [mentioned on twitter](https://twitter.com/marcphilipp/status/1170012808471355394) how to configure the signing plugin:
```
signing {
  sign(publishing.publications)
}
```

The setup as implemented in this PR is already working.

But I am now facing one last issue (that can be ignored, because publication on Maven-Central still works):

```
> Task :publishPluginMavenPublicationToLocalRepository
Multiple publications with coordinates 'org.example:plugin-maven-publish:0.1-SNAPSHOT' are published to repository 'local'. The publications will overwrite each other!
```

If you set the version to be a SNAPSHOT version (as I did):

https://github.com/jmini/gradle-sandbox/blob/1fe46bc1c031402a626b53150b33d55d6b0d4f4b/plugin-maven-publish/build.gradle#L8

When you observed the the result:

```
build/repo/
└── org
    └── example
        ├── hello
        │   └── org.example.hello.gradle.plugin
        │       ├── 0.1-SNAPSHOT
        │       │   ├── maven-metadata.xml
        │       │   ├── maven-metadata.xml.md5
        │       │   ├── maven-metadata.xml.sha1
        │       │   ├── org.example.hello.gradle.plugin-0.1-20190916.140455-1.pom
        │       │   ├── org.example.hello.gradle.plugin-0.1-20190916.140455-1.pom.asc
        │       │   ├── org.example.hello.gradle.plugin-0.1-20190916.140455-1.pom.asc.md5
        │       │   ├── org.example.hello.gradle.plugin-0.1-20190916.140455-1.pom.asc.sha1
        │       │   ├── org.example.hello.gradle.plugin-0.1-20190916.140455-1.pom.md5
        │       │   └── org.example.hello.gradle.plugin-0.1-20190916.140455-1.pom.sha1
        │       ├── maven-metadata.xml
        │       ├── maven-metadata.xml.md5
        │       └── maven-metadata.xml.sha1
        └── plugin-maven-publish
            ├── 0.1-SNAPSHOT
            │   ├── maven-metadata.xml
            │   ├── maven-metadata.xml.md5
            │   ├── maven-metadata.xml.sha1
            │   ├── plugin-maven-publish-0.1-20190916.140455-1-javadoc.jar
            │   ├── plugin-maven-publish-0.1-20190916.140455-1-javadoc.jar.asc
            │   ├── plugin-maven-publish-0.1-20190916.140455-1-javadoc.jar.asc.md5
            │   ├── plugin-maven-publish-0.1-20190916.140455-1-javadoc.jar.asc.sha1
            │   ├── plugin-maven-publish-0.1-20190916.140455-1-javadoc.jar.md5
            │   ├── plugin-maven-publish-0.1-20190916.140455-1-javadoc.jar.sha1
            │   ├── plugin-maven-publish-0.1-20190916.140455-1-sources.jar
            │   ├── plugin-maven-publish-0.1-20190916.140455-1-sources.jar.asc
            │   ├── plugin-maven-publish-0.1-20190916.140455-1-sources.jar.asc.md5
            │   ├── plugin-maven-publish-0.1-20190916.140455-1-sources.jar.asc.sha1
            │   ├── plugin-maven-publish-0.1-20190916.140455-1-sources.jar.md5
            │   ├── plugin-maven-publish-0.1-20190916.140455-1-sources.jar.sha1
            │   ├── plugin-maven-publish-0.1-20190916.140455-1.jar
            │   ├── plugin-maven-publish-0.1-20190916.140455-1.jar.asc
            │   ├── plugin-maven-publish-0.1-20190916.140455-1.jar.asc.md5
            │   ├── plugin-maven-publish-0.1-20190916.140455-1.jar.asc.sha1
            │   ├── plugin-maven-publish-0.1-20190916.140455-1.jar.md5
            │   ├── plugin-maven-publish-0.1-20190916.140455-1.jar.sha1
            │   ├── plugin-maven-publish-0.1-20190916.140455-1.pom
            │   ├── plugin-maven-publish-0.1-20190916.140455-1.pom.asc
            │   ├── plugin-maven-publish-0.1-20190916.140455-1.pom.asc.md5
            │   ├── plugin-maven-publish-0.1-20190916.140455-1.pom.asc.sha1
            │   ├── plugin-maven-publish-0.1-20190916.140455-1.pom.md5
            │   ├── plugin-maven-publish-0.1-20190916.140455-1.pom.sha1
            │   ├── plugin-maven-publish-0.1-20190916.140455-2.jar
            │   ├── plugin-maven-publish-0.1-20190916.140455-2.jar.asc
            │   ├── plugin-maven-publish-0.1-20190916.140455-2.jar.asc.md5
            │   ├── plugin-maven-publish-0.1-20190916.140455-2.jar.asc.sha1
            │   ├── plugin-maven-publish-0.1-20190916.140455-2.jar.md5
            │   ├── plugin-maven-publish-0.1-20190916.140455-2.jar.sha1
            │   ├── plugin-maven-publish-0.1-20190916.140455-2.pom
            │   ├── plugin-maven-publish-0.1-20190916.140455-2.pom.asc
            │   ├── plugin-maven-publish-0.1-20190916.140455-2.pom.asc.md5
            │   ├── plugin-maven-publish-0.1-20190916.140455-2.pom.asc.sha1
            │   ├── plugin-maven-publish-0.1-20190916.140455-2.pom.md5
            │   └── plugin-maven-publish-0.1-20190916.140455-2.pom.sha1
            ├── maven-metadata.xml
            ├── maven-metadata.xml.md5
            └── maven-metadata.xml.sha1
```

You see that `plugin-maven-publish-<version>.jar` is published twice.

The SNAPSHOT suffix (which is part of the result) gets evaluated twice when `0.1-SNAPSHOT` gets converted to a real value (containing the timestamp + a counter) inside the repository.

* first time:
  * `<artifact>-<version>-javadoc.jar`
  * `<artifact>-<version>-sources.jar`
  * `<artifact>-<version>.jar`
  * `<artifact>-<version>.pom`

* second time:
  * `<artifact>-<version>.jar`
  * `<artifact>-<version>.pom`


I guess that the `jar` and the `pom` are the same, so it is not that a big deal.

When you push to your maven local repository, in that case the `0.1-SNAPSHOT` version is not replaced to a unique value, the artifacts are just overridden.

To push to Maven Central, it seems that when you push an artifact with a stable version name (without a `SNAPSHOT` suffix), the temporary staging repository is accepting the override.

I have observed that other repository managers (like a company Nexus), might reject the second publication of an artifact already present inside the repository (published by the first run).

---

Is there a way to configure the `maven-publish` plugin to publish the jar and the pom only once?
