### PR TITLE
Fix PMD input file normalization

### DIFF
--- a/maven-cache-pmd-plugin/pom.xml
+++ b/maven-cache-pmd-plugin/pom.xml
@@ -101,11 +101,9 @@
                     <fileSets>
                       <fileSet>
                         <name>xrefLocation</name>
-                        <normalization>NAME_ONLY</normalization>
                       </fileSet>
                       <fileSet>
                         <name>xrefTestLocation</name>
-                        <normalization>NAME_ONLY</normalization>
                       </fileSet>
                       <fileSet>
                         <name>compileSourceRoots</name>
@@ -122,7 +120,7 @@
                       </fileSet>
                       <fileSet>
                         <name>excludeFromFailureFile</name>
-                        <normalization>NAME_ONLY</normalization>
+                        <normalization>IGNORED_PATH</normalization>
                       </fileSet>
                     </fileSets>
                   </inputs>


### PR DESCRIPTION
Correct normalization of input files:

- xrefLocation and xrefTestLocation are used to render relative links into
  the HTML report. So the contents of those files are not important for
  PMD report caching but their relative location. For this reason we set it
  to the default strategy which is RELATIVE_PATH.
- excludeFromFailureFile is a properties file containing class names to 
  exclude from PMD report generation. Name and path of that file are
  not important for caching, only the contents of that file will have an
  impact on the output. For that reason we set it to IGNORED_PATH.